### PR TITLE
HOMEWORK #22 – Hibernate Essentials. Action Queue. Flush

### DIFF
--- a/src/main/java/com/anderb/breskulorm/EntityKey.java
+++ b/src/main/java/com/anderb/breskulorm/EntityKey.java
@@ -1,13 +1,19 @@
 package com.anderb.breskulorm;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+import java.io.Serializable;
+
+@Getter
+@Setter
+@AllArgsConstructor
 public class EntityKey {
-    private final Object identifier;
+    private final Serializable identifier;
     private final EntityMetadata metadata;
 
-    public static EntityKey of(Object id, EntityMetadata metadata) {
+    public static EntityKey of(Serializable id, EntityMetadata metadata) {
         return new EntityKey(id, metadata);
     }
 

--- a/src/main/java/com/anderb/breskulorm/EntityMetadata.java
+++ b/src/main/java/com/anderb/breskulorm/EntityMetadata.java
@@ -1,5 +1,6 @@
 package com.anderb.breskulorm;
 
+import com.anderb.breskulorm.annotation.GenerationType;
 import lombok.Builder;
 import lombok.Data;
 
@@ -13,5 +14,9 @@ public class EntityMetadata {
     private final String idColumnName;
     private final String tableName;
     private final LinkedHashMap<String, Field> fields;
-    private final String updateSetValue;
+    private final Field idField;
+    private final String updateSetValueSql;
+    private final String insertSetValueSql;
+    private final EntityPersister persister;
+    private final GenerationType idGenerationType;
 }

--- a/src/main/java/com/anderb/breskulorm/EntityPersister.java
+++ b/src/main/java/com/anderb/breskulorm/EntityPersister.java
@@ -1,0 +1,207 @@
+package com.anderb.breskulorm;
+
+import com.anderb.breskulorm.exception.OrmException;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.sql.*;
+import java.util.Map;
+
+import static com.anderb.breskulorm.annotation.GenerationType.IDENTITY;
+import static java.sql.Statement.RETURN_GENERATED_KEYS;
+
+public class EntityPersister {
+
+    public static final Serializable POST_INSERT_INDICATOR = new Serializable() {
+    };
+
+    public Serializable getIdValue(Object instance, EntityMetadata metadata) {
+        try {
+            Field idField = metadata.getIdField();
+            idField.setAccessible(true);
+            return (Serializable) idField.get(instance);
+        } catch (IllegalAccessException e) {
+            throw new OrmException("Error fetch entity id value", e);
+        }
+    }
+
+    public Object loadFromDatasource(EntityKey key, Session session) {
+        try {
+            PreparedStatement stm = prepareFindByIdStatement(session.getConnection(), key);
+            ResultSet resultSet = stm.executeQuery();
+            return key.getMetadata().getPersister().mapToEntity(resultSet, key.getMetadata());
+        } catch (Exception e) {
+            throw new OrmException("Cannot load entity from DB", e);
+        }
+    }
+
+    public void update(EntityKey key, Object instance, Session session) {
+        try {
+            PreparedStatement stm = prepareUpdateStatement(session, key, instance);
+            int rowsUpdated = stm.executeUpdate();
+            if (rowsUpdated != 1) {
+                throw new OrmException("Cannot update entity " + key);
+            }
+        } catch (Exception e) {
+            throw new OrmException("Error", e);
+        }
+    }
+
+    public Serializable insert(EntityKey key, Object instance, Session session) {
+        try {
+            EntityMetadata metadata = key.getMetadata();
+            PreparedStatement stm = prepareInsertStatement(session, key, instance);
+            int rowsUpdated = stm.executeUpdate();
+            if (rowsUpdated != 1) {
+                throw new OrmException("Cannot insert entity " + metadata + ". No rows affected.");
+            }
+            try (ResultSet generatedKeys = stm.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    Serializable newId = (Serializable) generatedKeys.getObject(1);
+                    setIdentifier(metadata, instance, newId);
+                    return newId;
+                } else {
+                    throw new SQLException("Creating user failed, no ID obtained.");
+                }
+            }
+        } catch (Exception e) {
+            throw new OrmException("Error", e);
+        }
+    }
+
+    public void delete(EntityKey key, Session session) {
+        try {
+            PreparedStatement stm = prepareDeleteStatement(session.getConnection(), key);
+            int rowsUpdated = stm.executeUpdate();
+            if (rowsUpdated != 1) {
+                throw new OrmException("Cannot insert entity " + key);
+            }
+            session.getPersistenceContext().remove(key);
+            session.getSnapshots().remove(key);
+        } catch (Exception e) {
+            throw new OrmException("Error", e);
+        }
+    }
+
+    public void setIdentifier(EntityMetadata metadata, Object instance, Serializable value) {
+        Field idField = metadata.getIdField();
+        setValueToField(idField, instance, value);
+    }
+
+    public void setValueToField(Field field, Object instance, Object value) {
+        try {
+            field.setAccessible(true);
+            field.set(instance, value);
+        } catch (IllegalAccessException e) {
+            throw new OrmException("Cannot set value to field", e);
+        }
+    }
+
+    public <T> T mapToEntity(ResultSet resultSet, EntityMetadata metadata) throws Exception {
+        if (!resultSet.next()) {
+            return null;
+        }
+        T instance = (T) metadata.getType().getDeclaredConstructor().newInstance();
+        for (Map.Entry<String, Field> entry : metadata.getFields().entrySet()) {
+            setValueToField(entry.getValue(), instance, resultSet.getObject(entry.getKey()));
+        }
+        return instance;
+    }
+
+    public Serializable generateIdentifier(EntityMetadata entityMetadata, Session session) {
+        if (entityMetadata.getIdGenerationType() == IDENTITY) {
+            return POST_INSERT_INDICATOR;
+        }
+        return callNextSequenceValue(session);
+    }
+
+    private PreparedStatement prepareDeleteStatement(Connection connection, EntityKey key)
+            throws SQLException {
+        EntityMetadata metadata = key.getMetadata();
+        String sql = String.format(
+                "DELETE FROM %s WHERE %s=?",
+                metadata.getTableName(),
+                metadata.getIdColumnName()
+        );
+        PreparedStatement stm = connection.prepareStatement(sql);
+        stm.setObject(1, key.getIdentifier());
+        return stm;
+    }
+
+    private PreparedStatement prepareInsertStatement(Session session, EntityKey key, Object instance)
+            throws SQLException {
+        EntityMetadata metadata = key.getMetadata();
+        Serializable id = key.getIdentifier();
+        Object[] currentState = session.toSnapshot(metadata, instance);
+        boolean includeId = id != null;
+        String sql = String.format(
+                "INSERT INTO %s(%s) VALUES(%s)",
+                metadata.getTableName(),
+                metadata.getInsertSetValueSql(),
+                getValuesSigns(metadata.getFields().values().size(), includeId)
+        );
+        PreparedStatement stm = session.getConnection().prepareStatement(sql, RETURN_GENERATED_KEYS);
+        int i = 1;
+        while (i <= currentState.length) {
+            stm.setObject(i, currentState[i - 1]);
+            i++;
+        }
+        if (includeId) {
+            stm.setObject(i, id);
+        }
+        return stm;
+    }
+
+    private String getValuesSigns(int valuesSize, boolean includeIdField) {
+        int questionNumber = includeIdField ? valuesSize : valuesSize - 1;
+        return "?, ".repeat(questionNumber).substring(0, 3 * questionNumber - 2);
+    }
+
+    private PreparedStatement prepareUpdateStatement(Session session,
+                                                     EntityKey key,
+                                                     Object instance) throws SQLException {
+        EntityMetadata metadata = key.getMetadata();
+        Object[] currentState = session.toSnapshot(key.getMetadata(), instance);
+        String sql = String.format(
+                "UPDATE %s SET %s WHERE %s=?",
+                metadata.getTableName(),
+                metadata.getUpdateSetValueSql(),
+                metadata.getIdColumnName()
+        );
+        PreparedStatement stm = session.getConnection().prepareStatement(sql);
+        for (int i = 1; i <= currentState.length; i++) {
+            stm.setObject(i, currentState[i - 1]);
+        }
+        stm.setObject(currentState.length + 1, key.getIdentifier());
+        return stm;
+    }
+
+    private PreparedStatement prepareFindByIdStatement(Connection connection, EntityKey key) throws SQLException {
+        PreparedStatement stm = connection.prepareStatement(
+                String.format(
+                        "SELECT * FROM %s WHERE %s=?",
+                        key.getMetadata().getTableName(),
+                        key.getMetadata().getIdColumnName()
+                )
+        );
+        stm.setObject(1, key.getIdentifier());
+        return stm;
+    }
+
+    private Serializable callNextSequenceValue(Session session) {
+        try {
+            CallableStatement stm = session.getConnection()
+                    .prepareCall("call next value for orm_sequence");
+            ResultSet rs = stm.executeQuery();
+            if (rs.next()) {
+                return (Serializable) rs.getObject(1);
+            }
+            throw new OrmException("Cannot get sequence next value. ResultSet is empty!");
+        } catch (OrmException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OrmException("Cannot get sequence next value", e);
+        }
+    }
+
+}

--- a/src/main/java/com/anderb/breskulorm/Session.java
+++ b/src/main/java/com/anderb/breskulorm/Session.java
@@ -1,110 +1,107 @@
 package com.anderb.breskulorm;
 
+import com.anderb.breskulorm.action.*;
 import com.anderb.breskulorm.exception.OrmException;
 
-import javax.sql.DataSource;
-import java.lang.reflect.Field;
+import java.io.Serializable;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.anderb.breskulorm.EntityPersister.POST_INSERT_INDICATOR;
+
+
 public class Session implements AutoCloseable {
-
-    private final DataSource dataSource;
+    private final Connection connection;
     private final EntityMetadataResolver metadataResolver;
+    private final ActionQueue actionQueue;
 
-    private final Map<EntityKey, Object[]> snapshots = new HashMap<>();
+    private final Transaction transaction;
     private final Map<EntityKey, Object> persistenceContext = new HashMap<>();
+    private final Map<EntityKey, Object[]> snapshots = new HashMap<>();
     private boolean readOnly;
     private boolean closed;
 
-    public Session(DataSource dataSource, EntityMetadataResolver metadataResolver) {
-        this.dataSource = dataSource;
+    public Session(Connection connection, EntityMetadataResolver metadataResolver) {
+        this.connection = connection;
         this.metadataResolver = metadataResolver;
+        transaction = new Transaction(connection, this);
+        transaction.begin();
+        actionQueue = new ActionQueue();
     }
 
     public <T> T find(Class<T> type, Object id) {
         checkOpen();
         Object entity = persistenceContext.computeIfAbsent(
-                EntityKey.of(id, metadataResolver.getEntityMetadata(type)),
+                EntityKey.of((Serializable) id, metadataResolver.getEntityMetadata(type)),
                 this::loadFromDatasource);
         return type.cast(entity);
     }
 
-    public void close() {
-        closed = true;
-        flush();
-        persistenceContext.clear();
+    public void update(Object entity) {
+        checkOpen();
+        EntityKey key = getEntityKey(entity);
+        if (key == null) throw new IllegalStateException("Cannot get entity in context");
+        if (isDirty(key, entity)) {
+            fireUpdate(key, entity);
+        }
+    }
+
+    public void persist(Object entity) {
+        checkOpen();
+
+        EntityKey entityKey = getEntityKey(entity);
+        if (entityKey != null) return; //Ignoring persistent instance
+        EntityMetadata metadata = metadataResolver.getEntityMetadata(entity.getClass());
+        EntityPersister persister = metadata.getPersister();
+        Serializable generatedId = persister.generateIdentifier(metadata, this);
+        if (generatedId == POST_INSERT_INDICATOR) {
+            actionQueue.execute(new IdentityInsertAction(metadata, entity, this));
+            return;
+        }
+        EntityKey key = EntityKey.of(generatedId, metadata);
+        persister.setIdentifier(metadata, entity, generatedId);
+        persistenceContext.put(key, entity);
+        saveStateToSnapshotIfNeeded(key, entity);
+        firePersist(key, entity);
+    }
+
+    public void delete(Object entity) {
+        checkOpen();
+        EntityKey entityKey = getEntityKey(entity);
+        if (entityKey == null) throw new IllegalArgumentException("Removing a detached instance " + entity);
+        fireDelete(entityKey, entity);
     }
 
     public void flush() {
-        persistenceContext
-                .entrySet()
-                .stream()
-                .filter(entry -> snapshots.containsKey(entry.getKey()))
-                .forEach(entry -> {
-                    var currentState = toSnapshot(entry.getKey().getMetadata(), entry.getValue());
-                    if (isDirty(snapshots.get(entry.getKey()), currentState)) {
-                        executeUpdate(entry.getKey(), currentState);
-                    }
-                });
-        snapshots.clear();
-    }
-
-    public void setReadOnly(boolean readOnly) {
-        this.readOnly = readOnly;
+        persistenceContext.forEach(this::fireUpdate);
+        actionQueue.executeActions();
     }
 
     public boolean isClosed() {
         return closed;
     }
 
-    private void checkOpen() {
-        if (isClosed()) {
-            throw new IllegalStateException("Session is closed");
-        }
+    public Transaction getTransaction() {
+        return transaction;
     }
 
-    private <T> T loadFromDatasource(EntityKey key) {
-        try (Connection connection = dataSource.getConnection()) {
-            PreparedStatement stm = prepareFindByIdStatement(connection, key);
-            ResultSet resultSet = stm.executeQuery();
-            T entity = mapToEntity(resultSet, key.getMetadata());
-            saveStateToSnapshotIfNeeded(key, entity);
-            return entity;
-        } catch (Exception e) {
-            throw new OrmException("Cannot load entity from DB", e);
-        }
+    public Connection getConnection() {
+        return connection;
     }
 
-    private <T> void saveStateToSnapshotIfNeeded(EntityKey key, T entity) {
-        if (!readOnly) {
+    public EntityMetadataResolver getMetadataResolver() {
+        return metadataResolver;
+    }
+
+    public <T> void saveStateToSnapshotIfNeeded(EntityKey key, T entity) {
+        if (!readOnly && entity != null) {
             saveStateToSnapshot(key, entity);
         }
     }
 
-    private <T> T mapToEntity(ResultSet resultSet, EntityMetadata metadata) throws Exception {
-        if (!resultSet.next()) {
-            return null;
-        }
-        T instance = (T) metadata.getType().getDeclaredConstructor().newInstance();
-        for (Map.Entry<String, Field> entry : metadata.getFields().entrySet()) {
-            Field field = entry.getValue();
-            field.setAccessible(true);
-            field.set(instance, resultSet.getObject(entry.getKey()));
-        }
-        return instance;
-    }
-
-    private <T> void saveStateToSnapshot(EntityKey key, T entity) {
-        Object[] state = toSnapshot(key.getMetadata(), entity);
-        snapshots.put(key, state);
-    }
-
-    private <T> Object[] toSnapshot(EntityMetadata metadata, T entity) {
+    public <T> Object[] toSnapshot(EntityMetadata metadata, T entity) {
         return metadata.getFields().values()
                 .stream()
                 .filter(field -> !field.getName().equals(metadata.getIdColumnName()))
@@ -115,8 +112,98 @@ public class Session implements AutoCloseable {
                     } catch (IllegalAccessException e) {
                         throw new OrmException("Cannot get entity state", e);
                     }
-                }).toArray();
+                })
+                .toArray();
+    }
 
+    public Map<EntityKey, Object> getPersistenceContext() {
+        return persistenceContext;
+    }
+
+    public Map<EntityKey, Object[]> getSnapshots() {
+        return snapshots;
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    public void setReadOnly(boolean readOnly) {
+        this.readOnly = readOnly;
+    }
+
+    private void checkOpen() {
+        if (isClosed()) {
+            throw new IllegalStateException("Session is closed");
+        }
+    }
+
+    private void closeConnection() {
+        try {
+            connection.close();
+        } catch (SQLException ignored) {
+        }
+    }
+
+    public ActionQueue getActionQueue() {
+        return actionQueue;
+    }
+
+    public void close() {
+        closed = true;
+        flush();
+        transaction.commit();
+        clear();
+        closeConnection();
+    }
+
+    /**
+     * Clear session persistent context without flush to db
+     */
+    public void clear() {
+        persistenceContext.clear();
+        snapshots.clear();
+    }
+
+    private EntityKey getEntityKey(Object entity) {
+        return persistenceContext
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().equals(entity))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private Object loadFromDatasource(EntityKey key) {
+        Object entity = key.getMetadata().getPersister().loadFromDatasource(key, this);
+        saveStateToSnapshotIfNeeded(key, entity);
+        return entity;
+    }
+
+    private <T> void saveStateToSnapshot(EntityKey key, T entity) {
+        snapshots.put(key, toSnapshot(key.getMetadata(), entity));
+    }
+
+    private void fireUpdate(EntityKey key, Object instance) {
+        actionQueue.addAction(new UpdateAction(key, instance, this));
+    }
+
+    private void firePersist(EntityKey key, Object instance) {
+        actionQueue.addAction(new InsertAction(key, instance, this));
+    }
+
+    private void fireDelete(EntityKey entityKey, Object instance) {
+        actionQueue.addAction(new DeleteAction(entityKey, instance, this));
+    }
+
+    private boolean isDirty(EntityKey key, Object entity) {
+        if (isReadOnly()) return true;
+        Object[] snapshot = snapshots.get(key);
+        if (snapshot != null) {
+            return isDirty(snapshot, toSnapshot(key.getMetadata(), entity));
+        }
+        return true;
     }
 
     private boolean isDirty(Object[] previousState, Object[] currentState) {
@@ -126,49 +213,6 @@ public class Session implements AutoCloseable {
             }
         }
         return false;
-    }
-
-    private void executeUpdate(EntityKey key, Object[] currentState) {
-        try (Connection connection = dataSource.getConnection()) {
-            PreparedStatement stm = prepareUpdateStatement(connection, key, currentState);
-            int rowsUpdated = stm.executeUpdate();
-            if (rowsUpdated != 1) {
-                throw new OrmException("Cannot update entity " + key);
-            }
-        } catch (Exception e) {
-            throw new OrmException("Error", e);
-        }
-    }
-
-    private PreparedStatement prepareFindByIdStatement(Connection connection, EntityKey key) throws SQLException {
-        PreparedStatement stm = connection.prepareStatement(
-                String.format(
-                        "SELECT * FROM %s WHERE %s=?",
-                        key.getMetadata().getTableName(),
-                        key.getMetadata().getIdColumnName()
-                )
-        );
-        stm.setObject(1, key.getIdentifier());
-        return stm;
-    }
-
-    private PreparedStatement prepareUpdateStatement(Connection connection,
-                                                     EntityKey key,
-                                                     Object[] currentState) throws SQLException {
-        EntityMetadata metadata = key.getMetadata();
-        String sql = String.format(
-                "UPDATE %s SET %s WHERE %s=?",
-                metadata.getTableName(),
-                metadata.getUpdateSetValue(),
-                metadata.getIdColumnName()
-        );
-        PreparedStatement stm = connection.prepareStatement(sql);
-        int i = 1;
-        for (; i <= currentState.length; i++) {
-            stm.setObject(i, currentState[i - 1]);
-        }
-        stm.setObject(i, key.getIdentifier());
-        return stm;
     }
 
 }

--- a/src/main/java/com/anderb/breskulorm/SessionFactory.java
+++ b/src/main/java/com/anderb/breskulorm/SessionFactory.java
@@ -1,6 +1,9 @@
 package com.anderb.breskulorm;
 
+import com.anderb.breskulorm.exception.OrmException;
+
 import javax.sql.DataSource;
+import java.sql.SQLException;
 
 public class SessionFactory {
     private final DataSource dataSource;
@@ -12,6 +15,10 @@ public class SessionFactory {
     }
 
     public Session createSession() {
-        return new Session(dataSource, entityMetadataResolver);
+        try {
+            return new Session(dataSource.getConnection(), entityMetadataResolver);
+        } catch (SQLException e) {
+            throw new OrmException("Cannot create new Session", e);
+        }
     }
 }

--- a/src/main/java/com/anderb/breskulorm/Transaction.java
+++ b/src/main/java/com/anderb/breskulorm/Transaction.java
@@ -1,0 +1,53 @@
+package com.anderb.breskulorm;
+
+import com.anderb.breskulorm.exception.OrmException;
+import lombok.RequiredArgsConstructor;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@RequiredArgsConstructor
+public class Transaction {
+    private final Connection connection;
+    private final Session session;
+    private boolean isActive;
+
+    public void begin() {
+        if (session.isClosed()) {
+            throw new IllegalStateException("Cannot begin Transaction on closed Session/EntityManager");
+        }
+        try {
+            connection.setAutoCommit(false);
+            isActive = true;
+        } catch (SQLException e) {
+            throw new OrmException("Cannot begin transaction", e);
+        }
+    }
+
+    public void commit() {
+        try {
+            if (isActive) {
+                isActive = false;
+                connection.commit();
+            }
+        } catch (SQLException e) {
+            throw new OrmException("Cannot begin transaction", e);
+        }
+    }
+
+    public void rollback() {
+        try {
+            if (isActive) {
+                isActive = false;
+                connection.rollback();
+            }
+        } catch (SQLException e) {
+            throw new OrmException("Cannot begin transaction", e);
+        }
+    }
+
+    public boolean isActive() {
+        return isActive;
+    }
+
+}

--- a/src/main/java/com/anderb/breskulorm/action/Action.java
+++ b/src/main/java/com/anderb/breskulorm/action/Action.java
@@ -1,0 +1,17 @@
+package com.anderb.breskulorm.action;
+
+import com.anderb.breskulorm.EntityKey;
+import com.anderb.breskulorm.Session;
+import com.anderb.breskulorm.exception.OrmException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public abstract class Action {
+    private EntityKey key;
+    private Object instance;
+    private Session session;
+
+    abstract void execute() throws OrmException;
+}

--- a/src/main/java/com/anderb/breskulorm/action/ActionQueue.java
+++ b/src/main/java/com/anderb/breskulorm/action/ActionQueue.java
@@ -1,0 +1,94 @@
+package com.anderb.breskulorm.action;
+
+import com.anderb.breskulorm.exception.OrmException;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
+
+public class ActionQueue {
+    private static final LinkedHashMap<Class<? extends Action>, Function<ActionQueue, List<? extends Action>>> EXECUTABLE_LISTS_MAP;
+
+    static {
+        EXECUTABLE_LISTS_MAP = new LinkedHashMap<>(3);
+
+        EXECUTABLE_LISTS_MAP.put(
+                InsertAction.class,
+                (actionQueue) -> actionQueue.insertions
+        );
+        EXECUTABLE_LISTS_MAP.put(
+                UpdateAction.class,
+                (actionQueue) -> actionQueue.updates
+        );
+        EXECUTABLE_LISTS_MAP.put(
+                DeleteAction.class,
+                (actionQueue) -> actionQueue.deletions
+        );
+    }
+
+    private List<InsertAction> insertions;
+    private List<DeleteAction> deletions;
+    private List<UpdateAction> updates;
+
+    public void addAction(InsertAction action) {
+        if (insertions == null) {
+            insertions = new LinkedList<>();
+        }
+        insertions.add(action);
+    }
+
+    public void addAction(UpdateAction action) {
+        if (updates == null) {
+            updates = new LinkedList<>();
+        }
+        updates.add(action);
+    }
+
+    public void addAction(DeleteAction action) {
+        if (deletions == null) {
+            deletions = new LinkedList<>();
+        }
+        deletions.add(action);
+    }
+
+    public void executeActions() throws OrmException {
+        EXECUTABLE_LISTS_MAP.forEach((k, actionQueueProvider) -> {
+            var l = actionQueueProvider.apply(this);
+            if (l != null && !l.isEmpty()) {
+                executeActions(l);
+            }
+        });
+    }
+
+    public void executeActions(List<? extends Action> list) throws OrmException {
+        for (Action action : list) {
+            action.execute();
+        }
+        list.clear();
+    }
+
+    /**
+     * Execute {@link Action} immediately
+     *
+     * @param executable
+     * @param <E>
+     */
+    public <E extends Action> void execute(E action) {
+        action.execute();
+    }
+
+
+    public List<InsertAction> getInsertions() {
+        return insertions;
+    }
+
+    public List<DeleteAction> getDeletions() {
+        return deletions;
+    }
+
+    public List<UpdateAction> getUpdates() {
+        return updates;
+    }
+
+}

--- a/src/main/java/com/anderb/breskulorm/action/DeleteAction.java
+++ b/src/main/java/com/anderb/breskulorm/action/DeleteAction.java
@@ -1,0 +1,23 @@
+package com.anderb.breskulorm.action;
+
+import com.anderb.breskulorm.EntityKey;
+import com.anderb.breskulorm.EntityPersister;
+import com.anderb.breskulorm.Session;
+import com.anderb.breskulorm.exception.OrmException;
+
+public class DeleteAction extends Action {
+
+    public DeleteAction(EntityKey id, Object instance, Session session) {
+        super(id, instance, session);
+    }
+
+    @Override
+    void execute() throws OrmException {
+        EntityKey key = getKey();
+        Session session = getSession();
+        EntityPersister persister = key.getMetadata().getPersister();
+        persister.delete(key, session);
+        session.getPersistenceContext().remove(key);
+        session.getSnapshots().remove(key);
+    }
+}

--- a/src/main/java/com/anderb/breskulorm/action/IdentityInsertAction.java
+++ b/src/main/java/com/anderb/breskulorm/action/IdentityInsertAction.java
@@ -1,0 +1,27 @@
+package com.anderb.breskulorm.action;
+
+import com.anderb.breskulorm.EntityKey;
+import com.anderb.breskulorm.EntityMetadata;
+import com.anderb.breskulorm.Session;
+import com.anderb.breskulorm.exception.OrmException;
+
+import java.io.Serializable;
+
+public class IdentityInsertAction extends Action {
+    private final EntityMetadata metadata;
+
+    public IdentityInsertAction(EntityMetadata metadata, Object instance, Session session) {
+        super(null, instance, session);
+        this.metadata = metadata;
+    }
+
+    @Override
+    void execute() throws OrmException {
+        Session session = getSession();
+        Object instance = getInstance();
+        Serializable id = metadata.getPersister().insert(EntityKey.of(null, metadata), instance, session);
+        EntityKey key = EntityKey.of(id, metadata);
+        session.getPersistenceContext().put(key, instance);
+        session.saveStateToSnapshotIfNeeded(key, instance);
+    }
+}

--- a/src/main/java/com/anderb/breskulorm/action/InsertAction.java
+++ b/src/main/java/com/anderb/breskulorm/action/InsertAction.java
@@ -1,0 +1,24 @@
+package com.anderb.breskulorm.action;
+
+import com.anderb.breskulorm.EntityKey;
+import com.anderb.breskulorm.EntityMetadata;
+import com.anderb.breskulorm.EntityPersister;
+import com.anderb.breskulorm.Session;
+import com.anderb.breskulorm.exception.OrmException;
+
+public class InsertAction extends Action {
+
+    public InsertAction(EntityKey id, Object instance, Session session) {
+        super(id, instance, session);
+    }
+
+    @Override
+    void execute() throws OrmException {
+        EntityKey key = getKey();
+        EntityMetadata metadata = key.getMetadata();
+        Session session = getSession();
+        Object instance = getInstance();
+        EntityPersister persister = metadata.getPersister();
+        persister.insert(key, instance, session);
+    }
+}

--- a/src/main/java/com/anderb/breskulorm/action/UpdateAction.java
+++ b/src/main/java/com/anderb/breskulorm/action/UpdateAction.java
@@ -1,0 +1,25 @@
+package com.anderb.breskulorm.action;
+
+import com.anderb.breskulorm.EntityKey;
+import com.anderb.breskulorm.EntityPersister;
+import com.anderb.breskulorm.Session;
+import com.anderb.breskulorm.exception.OrmException;
+
+
+public class UpdateAction extends Action {
+
+    public UpdateAction(EntityKey key, Object instance, Session session) {
+        super(key, instance, session);
+    }
+
+    @Override
+    void execute() throws OrmException {
+        EntityKey key = getKey();
+        Session session = getSession();
+        Object instance = getInstance();
+        EntityPersister persister = key.getMetadata().getPersister();
+        persister.update(key, instance, session);
+        session.getPersistenceContext().put(key, instance);
+        session.saveStateToSnapshotIfNeeded(key, instance);
+    }
+}

--- a/src/main/java/com/anderb/breskulorm/annotation/GenerationType.java
+++ b/src/main/java/com/anderb/breskulorm/annotation/GenerationType.java
@@ -1,0 +1,6 @@
+package com.anderb.breskulorm.annotation;
+
+public enum GenerationType {
+    IDENTITY,
+    SEQUENCE
+}

--- a/src/main/java/com/anderb/breskulorm/annotation/Id.java
+++ b/src/main/java/com/anderb/breskulorm/annotation/Id.java
@@ -5,8 +5,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import static com.anderb.breskulorm.annotation.GenerationType.IDENTITY;
+
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Id {
     String value() default "";
+
+    GenerationType generatedValue() default IDENTITY;
 }

--- a/src/test/java/com/anderb/breskulorm/Address.java
+++ b/src/test/java/com/anderb/breskulorm/Address.java
@@ -1,0 +1,21 @@
+package com.anderb.breskulorm;
+
+import com.anderb.breskulorm.annotation.*;
+import lombok.Data;
+
+import static com.anderb.breskulorm.annotation.GenerationType.IDENTITY;
+
+@Data
+@Entity
+@Table("address")
+public class Address {
+    @Id(generatedValue = IDENTITY)
+    private Long id;
+
+    @Column("address_line")
+    private String addressLine;
+
+    @Column("city")
+    private String city;
+
+}

--- a/src/test/java/com/anderb/breskulorm/Person.java
+++ b/src/test/java/com/anderb/breskulorm/Person.java
@@ -1,16 +1,13 @@
 package com.anderb.breskulorm;
 
-import com.anderb.breskulorm.annotation.Column;
-import com.anderb.breskulorm.annotation.Entity;
-import com.anderb.breskulorm.annotation.Id;
-import com.anderb.breskulorm.annotation.Table;
+import com.anderb.breskulorm.annotation.*;
 import lombok.Data;
 
 @Data
 @Entity
 @Table("persons")
 public class Person {
-    @Id
+    @Id(generatedValue = GenerationType.SEQUENCE)
     private Long id;
 
     @Column("first_name")

--- a/src/test/resources/prepare-person.sql
+++ b/src/test/resources/prepare-person.sql
@@ -1,10 +1,22 @@
-CREATE TABLE IF NOT EXISTS PERSONS (
-    id BIGINT NOT NULL AUTO_INCREMENT,
+DROP TABLE IF EXISTS PERSONS;
+CREATE TABLE PERSONS (
+    id BIGINT NOT NULL,
     first_name VARCHAR(255) NOT NULL,
     last_name VARCHAR(255) NOT NULL,
     PRIMARY KEY (id)
 );
 
-INSERT INTO persons(first_name, last_name) VALUES ('Andrii', 'Bobrov');
-INSERT INTO persons(first_name, last_name) VALUES ('Ivan', 'Petrov');
-INSERT INTO persons(first_name, last_name) VALUES ( 'John', 'Doe');
+DROP SEQUENCE IF EXISTS orm_sequence;
+CREATE SEQUENCE orm_sequence start with 4;
+
+INSERT INTO persons(id, first_name, last_name) VALUES (1, 'Andrii', 'Bobrov');
+INSERT INTO persons(id, first_name, last_name) VALUES (2, 'Ivan', 'Petrov');
+INSERT INTO persons(id, first_name, last_name) VALUES (3, 'John', 'Doe');
+
+DROP TABLE IF EXISTS ADDRESS;
+CREATE TABLE ADDRESS (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    address_line VARCHAR(255) NOT NULL,
+    city VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);


### PR DESCRIPTION
 * Create/Update custom-orm-session  project with a custom Session class (see description above if you don’t have one)
 * Open transaction when the session is created, and commit/rollback it when it gets closed
 * Add two methods to the session persist, remove
 * Create two new classes that represent corresponding actions InsertAction, DeleteAction
 * Implement methods in a such way, that they create corresponding actions and add them to the queue called actionQueue. Make that queue an ordered one, so insert actions should be performed before delete actions.
 * Implement method flush that goes through all actions and performs corresponding SQL statements.
 * Update session so it calls flush before closing
 * Refactor your dirty checking mechanism so it creates UpdateAction and adds it to the queue